### PR TITLE
fix: revert Q73 answer to CDU/CSU+AfD (correct for 2025 Bundestag)

### DIFF
--- a/public/data/questions.json
+++ b/public/data/questions.json
@@ -7567,10 +7567,10 @@
     "category": "Politics",
     "question": "Die beiden größten Fraktionen im Deutschen Bundestag heißen zurzeit …",
     "options": [
-      "CDU/CSU und SPD.",
+      "CDU/CSU und AfD.",
       "Die Linke und Bündnis 90/Die Grünen.",
-      "FDP und SPD.",
-      "Die Linke und FDP."
+      "Bündnis 90/Die Grünen und SPD.",
+      "Die Linke und CDU/CSU."
     ],
     "answerIndex": 0,
     "explanation": "Die größten Fraktionen im Deutschen Bundestag sind CDU/CSU und AfD.",


### PR DESCRIPTION
After the 2025 federal election the 21st Bundestag seat order is: CDU/CSU (208) > AfD (152) > SPD (120).
CDU/CSU+AfD are the two largest fractions, not CDU/CSU+SPD.